### PR TITLE
Improve performance of NewTensor and Value for string tensors

### DIFF
--- a/tensorflow/go/tensor_test.go
+++ b/tensorflow/go/tensor_test.go
@@ -315,12 +315,28 @@ func BenchmarkTensor(b *testing.B) {
 		l3[i] = l2[i*100 : (i+1)*100]
 	}
 
+	s1 := make([]string, 100*100*100)
+	s2 := make([][]string, 100*100)
+	s3 := make([][][]string, 100)
+	for i := range s1 {
+		s1[i] = "cheesit"
+	}
+	for i := range s2 {
+		s2[i] = s1[i*100 : (i+1)*100]
+	}
+	for i := range s3 {
+		s3[i] = s2[i*100 : (i+1)*100]
+	}
+
 	tests := []interface{}{
 		vector,
 		arrays,
 		l1,
 		l2,
 		l3,
+		s1,
+		s2,
+		s3,
 	}
 	b.Run("New", func(b *testing.B) {
 		for _, test := range tests {


### PR DESCRIPTION
- add benchmark to highlight and track the issue
- follows on from a similar improvement for non-string tensors
- avoids allocations forced by using encoding/binary
- avoids CGO calls encoding and decoding TF strings. Do this in Go instead.
- avoid allocations for individual slices

Performance improvements are significant
```
name                          old time/op    new time/op    delta
Tensor/New/[]string-16           455ms ± 2%      33ms ± 2%   -92.74%  (p=0.001 n=7+7)
Tensor/New/[][]string-16         461ms ± 2%      35ms ± 5%   -92.51%  (p=0.000 n=8+8)
Tensor/New/[][][]string-16       461ms ± 1%      36ms ± 1%   -92.15%  (p=0.000 n=8+7)
Tensor/Value/[]string-16         289ms ± 1%      21ms ± 2%   -92.77%  (p=0.000 n=7+8)
Tensor/Value/[][]string-16       292ms ± 1%      21ms ± 2%   -92.89%  (p=0.000 n=8+8)
Tensor/Value/[][][]string-16     295ms ± 4%      21ms ± 1%   -92.92%  (p=0.001 n=8+6)

name                          old alloc/op   new alloc/op   delta
Tensor/New/[]string-16          48.0MB ± 0%     0.0MB ± 0%  -100.00%  (p=0.002 n=7+8)
Tensor/New/[][]string-16        48.3MB ± 0%     0.0MB ± 0%  -100.00%  (p=0.000 n=7+8)
Tensor/New/[][][]string-16      48.3MB ± 0%     0.0MB ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/Value/[]string-16        72.0MB ± 0%    23.0MB ± 0%   -68.04%  (p=0.001 n=6+7)
Tensor/Value/[][]string-16      74.5MB ± 0%    23.3MB ± 0%   -68.78%  (p=0.001 n=7+7)
Tensor/Value/[][][]string-16    74.5MB ± 0%    23.3MB ± 0%   -68.78%  (p=0.001 n=7+7)

name                          old allocs/op  new allocs/op  delta
Tensor/New/[]string-16           4.00M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/New/[][]string-16         4.01M ± 0%     0.00M ± 0%  -100.00%  (p=0.002 n=7+8)
Tensor/New/[][][]string-16       4.01M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/Value/[]string-16         6.00M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/Value/[][]string-16       6.02M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/Value/[][][]string-16     6.02M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=8+8)
```